### PR TITLE
feat: add installations repositories command to get repos for a given access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,20 @@
 
 simple app for interacting with github apps
 
-## Generate JWT for Github APP 
+## Generate JWT for Github APP
+
 You can generate a JWT for your github app by calling the following command 
 
 `./gh-app-adm jwt gen --private-key-path=YOUR_APPS_PRIVATE_KEY --app-id=YOUR_APPS_APPID`
 
-## List Installations 
+## List Installations
+
 You can list the installations for your github app by using the jwt generated above and calling the following command 
 
-`./gh-app-adm installations --jwt=YOUR_APPS_JWT` 
+`./gh-app-adm installations --jwt=YOUR_APPS_JWT`
 
-## Generate Access Token 
+## Generate Access Token
+
 You can generate an access token for your github app by using the above generated as well as an install-id from the output from the installations list command shown above. 
 
 `./gh-app-adm installations accessToken --jwt=YOUR_APPS_JWT --install-id=INSTALLATION_ID`

--- a/cmd/const.go
+++ b/cmd/const.go
@@ -2,6 +2,7 @@ package cmd
 
 const (
 	signedJwt      = `jwt`
+	token          = `token`
 	privateKeyPath = `private-key-path`
 	appId          = `app-id`
 	installId      = `install-id`


### PR DESCRIPTION
# Description

Added `installation repositories` command to make a request to the github `/installation/repositories` endpoint with an Authorized access token and retrieve repositories for the installation.